### PR TITLE
[PERF] switch from realpathSync -> readlinkSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function symlink(srcPath, destPath) {
     // because it doesn't use the standard library's `realpath`:
     // https://github.com/joyent/node/issues/7902
     // Can someone please send a patch to Node? :)
-    srcPath = options.fs.realpathSync(srcPath)
+     srcPath = options.fs.readlinkSync(srcPath)
   } else if (srcPath[0] !== '/') {
     // Resolve relative paths.
     // Note: On Mac and Linux (unlike Windows), process.cwd() never contains
@@ -83,7 +83,7 @@ function symlink(srcPath, destPath) {
 
 function symlinkWindows(srcPath, destPath) {
   if (options.canSymlink) {
-    srcPath = options.fs.realpathSync(srcPath)
+    srcPath = options.fs.readlinkSync(srcPath)
     var lstat = options.fs.lstatSync(srcPath)
     var isDir = lstat.isDirectory()
     options.fs.symlinkSync(srcPath, destPath, isDir ? 'dir' : 'file')

--- a/tests/index.js
+++ b/tests/index.js
@@ -34,7 +34,7 @@ describe('node-symlink-or-copy', function() {
             }
           }
         },
-        realpathSync: function() {count++},
+        readlinkSync: function() {count++},
         symlinkSync: function() {count++;}
       },
       canSymlink: true
@@ -61,7 +61,7 @@ describe('testing mode', function() {
             }
           }
         },
-        realpathSync: function() {count++},
+        readlinkSync: function() {count++},
         symlinkSync: function() {count++;}
       }
     });


### PR DESCRIPTION
@joliss has already identified nodes performance issues with realpath [here](https://github.com/joyent/node/issues/7902)

As per @krisselden's suggestion, we can likely just use `readlinkSync` here instead.

real life example: https://github.com/ember-cli/stress-app
before: `8668.970928ms`
after: `7152.094867ms`

`18%` improvement to incremental builds

As `realpathSync` uses `readlinkSync` internally, this also reduces calls to `readlinkSync`
before: `17826 (134.230726ms)`
after:   `6171 ( 93.061130ms)`