### PR TITLE
Make sure canLinkDest.tmp doesn't exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ function testCanSymlink () {
   var canLinkSrc  = path.join(tmpdir, "canLinkSrc.tmp")
   var canLinkDest = path.join(tmpdir, "canLinkDest.tmp")
 
+  try { 
+    fs.unlinkSync(canLinkDest)
+  } catch (e) { }
+
   try {
     fs.writeFileSync(canLinkSrc, '');
   } catch (e) {


### PR DESCRIPTION
While testing if we're able to create symbolic links under windows, we must ensure canLinkDest.tmp doesn't exists, otherwise we willl fallback to copy forever.

The error we get if the canLinkDest.tmp file exists during the test.

{ 
  [Error: EEXIST: file already exists, symlink 'C:\Users\JDoe\AppData\Local\Temp\canLinkSrc.tmp' -> 'C:\Users\JDoe\AppData\Local\Temp\canLinkDest.tmp']
  errno: -4075,
  code: 'EEXIST',
  syscall: 'symlink',
  path: 'C:\\Users\\JDoe\\AppData\\Local\\Temp\\canLinkSrc.tmp',
  dest: 'C:\\Users\\JDoe\\AppData\\Local\\Temp\\canLinkDest.tmp' 
}