### PR TITLE
Faster for the pour souls without symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,11 @@ dereferenced before symlinking, to avoid runaway symlink indirection.
 
 ## Notes
 
-* Symlinks could technically work on Windows, but they require special rights.
-There are also junctions, but it's not clear whether they are useful. We might
-want to be smarter about using symlinks on Windows when we can, but at the
-moment we opt for the simplest solution (always copying), even though it
-sacrifices performance on Windows.
+* Symlinks technically work on Windows, but they require special rights. For
+  users with those rights, symlinks are used, but when not available, a
+  combination of junctions and copying is used to mimic the behavior somewhat
+  performantly.
 
-* There intentionally isn't an asynchronous version. It's not clear that we
-need or want one. Before sending a patch to add an async version, please share
-your use case on the issue tracker.
+* There intentionally isn't an asynchronoukks version. It's not clear that we
+  need or want one. Before sending a patch to add an async version, please
+  share your use case on the issue tracker.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,10 @@ version: '{build}'
 
 environment:
   matrix:
-    - nodejs_version: '2.0'
-    - nodejs_version: '1.8.1'
+    - nodejs_version: '0.10'
     - nodejs_version: '0.12'
+    - nodejs_version: '4.2'
+    - nodejs_version: '5.0'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "type": "git",
     "url": "https://github.com/broccolijs/node-symlink-or-copy"
   },
-  "dependencies": {
-    "copy-dereference": "^1.0.0"
-  },
   "scripts": {
-    "test": "mocha tests/"
+    "test": "mocha tests/",
+    "test:debug": "mocha debug tests"
   },
   "devDependencies": {
     "mocha": "^2.2.4"


### PR DESCRIPTION
Note, this is for users without symlinks enabled. If you are a windows users with slow rebuilds, please be sure to follow: http://ember-cli.com/user-guide/#symlinks-on-windows and your rebuilds should be much better.

Also note, we will continue to reduce the reliance on symlinks (as time permits) but this is rather low hanging fruit and will help those poor souls without symlinks today.

Note: these numbers are from my windows 10 VM, unsure how they perform on the metal... But less IO is less IO.

initial build:
* before (42,000ms):
* after  (11,000ms):

rebuild:
* before  (27,000ms):
* after (1,000ms) ( sometimes as low as 650ms)

TODO:

- [x] make work
- [x] test windows
- [x] confirm with others
- [x] update readme

----

before (initial build) (42,000ms):

<img width="542" alt="screen shot 2016-04-03 at 10 16 46 pm" src="https://cloud.githubusercontent.com/assets/1377/14238796/cc6a669c-f9e9-11e5-8e69-9c7c05a2e2b6.png">

after (initial build) (11,000ms):

<img width="745" alt="screen shot 2016-04-03 at 10 09 58 pm" src="https://cloud.githubusercontent.com/assets/1377/14238798/d3bf511e-f9e9-11e5-9702-35fe738c607a.png">

before (rebuild) (27,000ms):

<img width="523" alt="screen shot 2016-04-03 at 10 17 31 pm" src="https://cloud.githubusercontent.com/assets/1377/14238800/ea7620c2-f9e9-11e5-8087-5b9e3687840f.png">

after (rebuild) (1,000ms):

<img width="594" alt="screen shot 2016-04-03 at 10 23 14 pm" src="https://cloud.githubusercontent.com/assets/1377/14238884/c90aa36c-f9ea-11e5-903c-1f2a5dc78d58.png">
