### PR TITLE
Fix typo in srcPath assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function symlinkWindows(srcPath, destPath) {
   var wasResolved = false;
 
   if (stat.isSymbolicLink()) {
-    src = options.fs.realpathSync(srcPath);
+    srcPath = options.fs.realpathSync(srcPath);
     isDir = options.fs.lstatSync(srcPath).isDirectory();
     wasResolved = true;
   }


### PR DESCRIPTION
Unfortunately this typo caused us some headaches in our CI build today.

Otherwise, thanks for the changes. Looks like it's working well in our Windows environments so far (aside from the typo mentioned).