### PR TITLE
 [ERROR-FIX] The broccoli Plugin: [Funnel : Funnel (config)] failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,13 +80,13 @@ function symlink(srcPath, destPath) {
 }
 
 function symlinkWindows(srcPath, destPath) {
-  var stat = options.fs.lstatSync(srcPath)
+  var stat = options.fs.statSync(srcPath)
   var isDir = stat.isDirectory()
   var wasResolved = false;
 
   if (stat.isSymbolicLink()) {
     src = options.fs.realpathSync(srcPath);
-    isDir = options.fs.lstatSync(srcPath).isDirectory();
+    isDir = options.fs.statSync(srcPath).isDirectory();
     wasResolved = true;
   }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -8,7 +8,7 @@ describe('node-symlink-or-copy', function() {
 
   it('windows falls back to junction for dir', function() {
     var count = 0;
-    var lstatSyncCount = 0;
+    var statSyncCount = 0;
     var isDirectoryCount = 0;
     symLinkOrCopy.setOptions({
       isWindows: true,
@@ -17,8 +17,8 @@ describe('node-symlink-or-copy', function() {
       },
       canSymLink: false,
       fs: {
-       lstatSync: function() {
-         lstatSyncCount++;
+       statSync: function() {
+         statSyncCount++;
           return {
             isSymbolicLink: function() {
               return true;
@@ -35,14 +35,14 @@ describe('node-symlink-or-copy', function() {
     });
     symLinkOrCopy.sync('foo', 'bar');
     assert.equal(count, 2);
-    assert.equal(lstatSyncCount, 2);
+    assert.equal(statSyncCount, 2);
     assert.equal(isDirectoryCount, 2);
   });
 
 
   it('windows falls back to copy for file', function() {
     var count = 0
-    var lstatSyncCount = 0
+    var statSyncCount = 0
     var isDirectoryCount = 0
     var readFileSyncCount = 0
     var writeFileSyncCount = 0
@@ -54,8 +54,8 @@ describe('node-symlink-or-copy', function() {
       },
       canSymLink: false,
       fs: {
-       lstatSync: function() {
-         lstatSyncCount++
+       statSync: function() {
+         statSyncCount++
             return {
               isSymbolicLink: function() {
                 return true
@@ -82,7 +82,7 @@ describe('node-symlink-or-copy', function() {
 
     symLinkOrCopy.sync('foo', 'bar');
     assert.equal(count, 1);
-    assert.equal(lstatSyncCount, 2);
+    assert.equal(statSyncCount, 2);
     assert.equal(isDirectoryCount, 2);
     assert.equal(writeFileSyncCount, 1);
     assert.equal(readFileSyncCount, 1);
@@ -93,7 +93,7 @@ describe('node-symlink-or-copy', function() {
     var count = 0;
     symLinkOrCopy.setOptions({
       fs: {
-       lstatSync: function() {
+       statSync: function() {
           return {
             isSymbolicLink: function() {
               count++;
@@ -121,7 +121,7 @@ describe('testing mode', function() {
     symLinkOrCopy.setOptions({
       canSymlink: true,
       fs: {
-        lstatSync: function() {
+        statSync: function() {
           return {
             isSymbolicLink: function() {
               count++;

--- a/tests/index.js
+++ b/tests/index.js
@@ -121,7 +121,7 @@ describe('testing mode', function() {
     symLinkOrCopy.setOptions({
       canSymlink: true,
       fs: {
-        statSync: function() {
+        lstatSync: function() {
           return {
             isSymbolicLink: function() {
               count++;


### PR DESCRIPTION
Following is the error logged in the console while serving the fresh project using ember-cli:

```
The Broccoli Plugin: [Funnel: Funnel (config)] failed with:
Error: EISDIR, illegal operation on a directory
    at Error (native)
    at Object.fs.readSync (fs.js:552:19)
    at Object.fs.readFileSync (fs.js:389:28)
    at symlinkWindows (C:\emberjs\newProject\node_modules\ember-cli\node_modules
\symlink-or-copy\index.js:99:53)
    at Function.symlinkOrCopySync (C:\emberjs\newProject\node_modules\ember-cli\
node_modules\symlink-or-copy\index.js:53:5)
...
```

**System Info**
ember-cli: 2.5.0
node: 0.12.9
os: win32 x64

**Resolution:** 
lstatSync was failing for low privilege user windows user. So statSync is used instead of lstatSync for windows user. 
