### PR TITLE
Revert "Make sure canLinkDest.tmp doesn't exists"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var fs = require('fs-extra')
-var mktemp = require('mktemp');
+var fs = require('fs')
+var tmpdir = require('os').tmpdir();
 var path = require('path')
 
 var isWindows = process.platform === 'win32'
@@ -15,12 +15,8 @@ function testCanSymlink () {
   // its defined
   if (isWindows === false) { return true; }
 
-  fs.mkdirSync('tmp');
-
-  var tmpdir = mktemp.createDirSync('tmp/XXXXX.tmp');
-
-  var canLinkSrc  = tmpdir + '/canLinkSrc.tmp';
-  var canLinkDest = tmpdir + '/canLinkDest.tmp';
+  var canLinkSrc  = path.join(tmpdir, "canLinkSrc.tmp")
+  var canLinkDest = path.join(tmpdir, "canLinkDest.tmp")
 
   try {
     fs.writeFileSync(canLinkSrc, '');
@@ -35,7 +31,8 @@ function testCanSymlink () {
     return false
   }
 
-  fs.remove(tmpdir);
+  fs.unlinkSync(canLinkSrc)
+  fs.unlinkSync(canLinkDest)
 
   return true
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,5 @@
   },
   "devDependencies": {
     "mocha": "^2.2.4"
-  },
-  "dependencies": {
-    "fs-extra": "^0.28.0",
-    "mktemp": "^0.4.0"
   }
 }


### PR DESCRIPTION
This reverts commit 800ef4fe90c34ef7201521d411300533d0e1ddd1.

[fixes #26]