### PR TITLE
Add canSymlink property to export

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,12 @@ function symlinkOrCopySync (srcPath, destPath) {
   }
 }
 
+Object.defineProperty(module.exports, 'canSymlink', {
+  get: function() {
+    return !!options.canSymlink;
+  }
+});
+
 function symlink(_srcPath, _destPath) {
   var srcPath = cleanup(_srcPath);
   var destPath = cleanup(_destPath);

--- a/tests/index.js
+++ b/tests/index.js
@@ -113,6 +113,16 @@ describe('node-symlink-or-copy', function() {
     symLinkOrCopy.sync('foo', 'bar');
     assert.equal(count, 3);
   })
+
+  it('exposes options.canSymlink via the canSymlink property', function() {
+    assert.equal(symLinkOrCopy.canSymlink, false, 'undefined is coerced to false');
+
+    symLinkOrCopy.setOptions({ canSymlink: true});
+    assert.equal(symLinkOrCopy.canSymlink, true, 'returns true');
+
+    symLinkOrCopy.setOptions({ canSymlink: false});
+    assert.equal(symLinkOrCopy.canSymlink, false, 'returns false');
+  });
 });
 
 describe('WSL issues', function() {


### PR DESCRIPTION
Allows other consumers to be aware of what behavior is being used (ref: https://github.com/stefanpenner/fs-tree-diff/pull/49).

cc @rwjblue 