### PR TITLE
Quick fix for ember s build issues when using ember-d3 in applications on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,10 @@ function symlinkWindows(srcPath, destPath) {
   srcPath = WINDOWS_PREFIX + (wasResolved ? srcPath : path.resolve(srcPath));
   destPath = WINDOWS_PREFIX + path.resolve(path.normalize(destPath));
 
+  if(!options.fs.existsSync(path.dirname(destPath))){
+    options.fs.mkdirSync(path.dirname(destPath));
+  }
+
   if (options.canSymlink) {
     options.fs.symlinkSync(srcPath, destPath, isDir ? 'dir' : 'file');
   } else {


### PR DESCRIPTION
Not sure if a general problem or related to ember-d3
=> needs more investigating

However, this seems to have fixed the error below on a windows 10
box with symlinks/developer mode enabled.

`The Broccoli Plugin: [Funnel] failed with:
Error: ENOENT: no such file or directory, symlink '[...]\tmp\ember-d3\register-version.js' -> '[...]\tmp\funnel-output_path-3RdeUspu.tmp\ember-d3\register-d3-version.js'`

Culprit is the missing ember-d3 directory in the destination path.

This provides a quick fix by creating the parent dir containing the
symlink on windows if it does not exist before attempting to symlink.