### PR TITLE
Fixed typos and logic errors in the one method the tests couldn't touch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/index.js
+++ b/index.js
@@ -36,9 +36,9 @@ function testCanSymlink () {
 
   try {
     fs.symlinkSync(canLinkSrc, canLinkDest);
-      result.files = true;
+    result.files = true;
   } catch (e) {
-      result.files = false;
+    result.files = false;
   }
 
   fs.unlinkSync(canLinkSrc);
@@ -61,7 +61,7 @@ function testCanSymlink () {
     fs.symlinkSync(canLinkSrc, canLinkDest, 'dir');
     fs.rmdirSync(canLinkSrc)
     fs.rmdirSync(canLinkDest)
-      result.directories = true;
+    result.directories = true;
   } catch (e) {
     fs.rmdirSync(canLinkSrc)
     result.directories = false;

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ var canSymlink = testCanSymlink();
 // These can be overridden for testing
 var defaultOptions = {
   isWindows: process.platform === 'win32',
-  canSymlinkFile: canSymlink.file,
-  canSymlinkDirectory: canSymlink.directory,
+  canSymlinkFile: canSymlink.files,
+  canSymlinkDirectory: canSymlink.directories,
   fs: fs
 };
 var options = defaultOptions;
@@ -36,12 +36,17 @@ function testCanSymlink () {
 
   try {
     fs.symlinkSync(canLinkSrc, canLinkDest);
+      result.files = true;
   } catch (e) {
-    result.files = false;
+      result.files = false;
   }
 
   fs.unlinkSync(canLinkSrc);
-  fs.unlinkSync(canLinkDest);
+  try {
+    fs.unlinkSync(canLinkDest);
+  } catch (e) {
+    // In case the link failed
+  }
 
   // Test symlinking a directory. For some reason, sometimes Windows allows
   // symlinking a file but not symlinking a directory...
@@ -54,14 +59,13 @@ function testCanSymlink () {
 
   try {
     fs.symlinkSync(canLinkSrc, canLinkDest, 'dir');
+    fs.rmdirSync(canLinkSrc)
+    fs.rmdirSync(canLinkDest)
+      result.directories = true;
   } catch (e) {
     fs.rmdirSync(canLinkSrc)
     result.directories = false;
   }
-
-  fs.rmdirSync(canLinkSrc)
-  fs.rmdirSync(canLinkDest)
-  result.directories = true;
 
   return result;
 }


### PR DESCRIPTION
As written, the code in testCanSymlink () would always return false for files and true for directories, whatever the outcome of the check. In fact, it would crash out from trying to delete (without a catch) a linked file that was never created. This was the one method that the mocha tests could not actually verify, since it required changing the system configuration to cycle through the possible results.

To test it, I verified my results on a Windows 10 system, toggling developer mode on and off. (On Linux, it sees that it isn't Windows and returns false for both, even though symbolic links undoubtedly work well here. I left that behavior alone.) I also have run the mocha test suite locally on Windows and Linux and it passes.

If my analysis of the code completely missed the point of what the code was intended to do, please explain what was intended, accept my apologies, and reject the PR.